### PR TITLE
언론사별 랭킹 페이지 타이틀 수정

### DIFF
--- a/src/pages/ranking/[pressname]/PressRankingRack.tsx
+++ b/src/pages/ranking/[pressname]/PressRankingRack.tsx
@@ -32,7 +32,7 @@ const PressRankingRack = ({ pressName, pressImgSrc, pressContent }: RankingType)
     <div className="w-[100vw] h-full p-4 flex flex-col gap-10">
       <div className="flex items-center gap-3">
         {pressImgSrc && (
-          <div className="md:w-[50px] w-[45px] md:h-[50px] h-[45px] rounded-full bg-BLACK">
+          <div className="md:w-[50px] w-[45px] md:h-[50px] h-[45px] flex flex-col justify-center rounded-full bg-BLACK">
             <Image
               src={pressImgSrc}
               alt="IT/Science News page icon"


### PR DESCRIPTION
## 변경사항

- 언론사별 랭킹 페이지 타이틀 부분 언론사 이미지 flex 적용