### PR TITLE
fix: ranking 페이지에 react-query 적용, SEO 최적화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,11 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^5.59.19",
     "axios": "^1.7.2",
     "cheerio": "^1.0.0-rc.12",
+    "date-fns": "^4.1.0",
     "next": "13.1.5",
     "next-seo": "^6.5.0",
     "next-themes": "^0.3.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,15 @@
+# Block all crawlers for below pages
+User-agent: *
+Disallow: /social
+Disallow: /economy
+Disallow: /world
+Disallow: /politics
+Disallow: /it_science
+Disallow: /ranking/*
+
+
+# Allow all crawlers
+User-agent: *
+Allow: /
+
+Sitemap: https://doyeonlee.vercel.app/sitemap.xml

--- a/src/hooks/useRankingDatas.ts
+++ b/src/hooks/useRankingDatas.ts
@@ -1,0 +1,18 @@
+import { RankingType } from "@/types/DataType";
+import { useQuery } from "@tanstack/react-query";
+
+const fetchRankingDatas = async (pressname: string): Promise<RankingType> => {
+  const response = await fetch(`/api/ranking/${pressname}`);
+  const data = await response.json();
+
+  return data;
+};
+
+const useRankingDatas = (pressname: string) => {
+  return useQuery({
+    queryKey: [pressname],
+    queryFn: () => fetchRankingDatas(pressname),
+  });
+};
+
+export { useRankingDatas, fetchRankingDatas };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,21 +6,21 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AppProps } from "next/app";
 
 const DEFAULT_SEO = {
-  title: "Nhips",
+  title: "Nhips | 간편한 뉴스",
   description: "간식처럼 간편하게 뉴스를 즐길 수 있게 만드는 웹 서비스 입니다.",
   canonical: "https://nhips.vercel.app/",
   openGraph: {
     type: "website",
     locale: "ko_KR",
     url: "https://nhips.vercel.app/",
-    title: "Nhips",
-    site_name: "Nhips",
+    title: "Nhips | 간편한 뉴스",
+    site_name: "Nhips | 간편한 뉴스",
     images: [
       {
         url: "/share.png",
         width: 285,
         height: 167,
-        alt: "Nhips",
+        alt: "Nhips | 간편한 뉴스",
       },
     ],
   },
@@ -33,11 +33,11 @@ const DEFAULT_SEO = {
   additionalMetaTags: [
     {
       name: "application-name",
-      content: "Nhips",
+      content: "Nhips | 간편한 뉴스",
     },
     {
       name: "msapplication-tooltip",
-      content: "Nhips",
+      content: "Nhips | 간편한 뉴스",
     },
     {
       name: "viewport",

--- a/src/pages/api/ranking/CA/index.ts
+++ b/src/pages/api/ranking/CA/index.ts
@@ -6,7 +6,25 @@ const CARankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await CARankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await CARankingNews;
+
+    // etag를 통해 이전에 받은 정보와 동일한지 확인
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      // 304 Not Modified로 요청을
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/HAN/index.ts
+++ b/src/pages/api/ranking/HAN/index.ts
@@ -6,7 +6,23 @@ const HANRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await HANRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await HANRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/JTBC/index.ts
+++ b/src/pages/api/ranking/JTBC/index.ts
@@ -6,7 +6,23 @@ const JTBCRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await JTBCRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await JTBCRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/KBS/index.ts
+++ b/src/pages/api/ranking/KBS/index.ts
@@ -6,7 +6,23 @@ const KBSRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await KBSRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await KBSRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/MBC/index.ts
+++ b/src/pages/api/ranking/MBC/index.ts
@@ -6,7 +6,23 @@ const MBCRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await MBCRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await MBCRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/MBN/index.ts
+++ b/src/pages/api/ranking/MBN/index.ts
@@ -6,7 +6,23 @@ const MBNRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await MBNRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await MBNRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/SBS/index.ts
+++ b/src/pages/api/ranking/SBS/index.ts
@@ -6,7 +6,23 @@ const SBSRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await SBSRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await SBSRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/YH/index.ts
+++ b/src/pages/api/ranking/YH/index.ts
@@ -6,7 +6,23 @@ const YHRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await YHRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await YHRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/api/ranking/YTN/index.ts
+++ b/src/pages/api/ranking/YTN/index.ts
@@ -6,7 +6,23 @@ const YTNRankingNews = getRankingData(
 );
 
 const crawlerHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json(await YTNRankingNews);
+  try {
+    const ifNoneMatch = req.headers["if-none-match"];
+    const data = await YTNRankingNews;
+
+    const etag = `"${Buffer.from(JSON.stringify(data)).toString("base64")}"`;
+
+    if (ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+
+    res.setHeader("ETag", etag);
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("Error fetching ranking data:", error);
+    res.status(500).json({ message: "서버 오류로 랭킹 데이터를 가져올 수 없습니다." });
+  }
 };
 
 export default crawlerHandler;

--- a/src/pages/components/InformationBox.tsx
+++ b/src/pages/components/InformationBox.tsx
@@ -1,5 +1,8 @@
 import RankingSection from "./RankingSection";
 import WeatherSection from "./WeatherSection";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import { GetStaticProps } from "next";
+import { fetchRankingDatas } from "../../hooks/useRankingDatas";
 
 const InformationBox = () => {
   return (
@@ -10,6 +13,59 @@ const InformationBox = () => {
       </div>
     </div>
   );
+};
+
+// 모든 페이지 데이터 preload
+export const getStaticProps: GetStaticProps = async () => {
+  const queryClient = new QueryClient();
+
+  // prefetch
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: ["CA"],
+      queryFn: () => fetchRankingDatas("CA"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["HAN"],
+      queryFn: () => fetchRankingDatas("HAN"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["JTBC"],
+      queryFn: () => fetchRankingDatas("JTBC"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["KBS"],
+      queryFn: () => fetchRankingDatas("KBS"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["MBC"],
+      queryFn: () => fetchRankingDatas("MBC"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["MBN"],
+      queryFn: () => fetchRankingDatas("MBN"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["SBS"],
+      queryFn: () => fetchRankingDatas("SBS"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["YH"],
+      queryFn: () => fetchRankingDatas("YH"),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["YTN"],
+      queryFn: () => fetchRankingDatas("YTN"),
+    }),
+  ]);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+    // 60초마다 데이터 재검증
+    revalidate: 60,
+  };
 };
 
 export default InformationBox;

--- a/src/pages/components/NewsItems/RankingNewsList.tsx
+++ b/src/pages/components/NewsItems/RankingNewsList.tsx
@@ -1,8 +1,16 @@
 import Image from "next/image";
+import Link from "next/link";
 import { PressContentType } from "@/types/DataType";
 import { MdOutlineRemoveRedEye } from "react-icons/md";
+import { FiLink } from "react-icons/fi";
 
-const NewsList = ({ list_id, headline, imgSrc, link, viewCount }: PressContentType | any) => {
+const RankingNewsList = ({
+  list_id,
+  headline,
+  imgSrc,
+  link,
+  viewCount,
+}: PressContentType | any) => {
   return (
     <div className="md:w-96 w-full max-h-full p-3 dark:bg-CARD_BG_DARK bg-CARD_BG_LIGHT rounded-sm">
       {headline ? (
@@ -10,12 +18,18 @@ const NewsList = ({ list_id, headline, imgSrc, link, viewCount }: PressContentTy
           <span className="md:w-[30px] w-[20px] font-HAKGYO md:text-lg text-base">
             {list_id + 1}
           </span>
-          {imgSrc && (
-            <a href={link} target="_blank" rel="noreferrer">
+          {imgSrc ? (
+            <Link href={link} target="_blank" rel="noreferrer">
               <div className="w-[100px] md:h-[75px] h-[90px] flex justify-center">
-                <Image src={imgSrc} alt="News Image" width={100} height={100} />
+                <Image src={imgSrc} alt="News Image" width={100} height={100} priority />
               </div>
-            </a>
+            </Link>
+          ) : (
+            <Link href={link} target="_blank" rel="noreferrer">
+              <div className="w-[100px] md:h-[75px] h-[90px] flex text-sm items-center justify-center bg-GRAY_EXTRADARK">
+                <FiLink />
+              </div>
+            </Link>
           )}
           <div className="flex flex-col gap-3 justify-between">
             <a href={link} target="_blank" rel="noreferrer">
@@ -36,4 +50,4 @@ const NewsList = ({ list_id, headline, imgSrc, link, viewCount }: PressContentTy
   );
 };
 
-export default NewsList;
+export default RankingNewsList;

--- a/src/pages/components/NewsItems/RankingNewsRack.tsx
+++ b/src/pages/components/NewsItems/RankingNewsRack.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { RankingType } from "@/types/DataType";
-import NewsList from "@/components/NewsItems/NewsList";
+import RankingNewsList from "@/components/NewsItems/RankingNewsList";
 
 const PressRankingRack = ({ pressName, pressImgSrc, pressContent }: RankingType) => {
   const colLeft = [
@@ -39,6 +39,7 @@ const PressRankingRack = ({ pressName, pressImgSrc, pressContent }: RankingType)
               width={100}
               height={100}
               className="rounded-full"
+              priority
             />
           ) : (
             ""
@@ -54,12 +55,12 @@ const PressRankingRack = ({ pressName, pressImgSrc, pressContent }: RankingType)
       <div className="w-full h-full flex md:flex-row flex-col gap-5">
         <div className="w-full h-full flex flex-col flex-wrap justify-center items-end gap-5">
           {colLeft.map((item, idx) => (
-            <NewsList key={idx} {...item} list_id={idx} />
+            <RankingNewsList key={idx} {...item} list_id={idx} />
           ))}
         </div>
         <div className="w-full h-full flex flex-col flex-wrap justify-center items-start gap-5">
           {colRight.map((item, idx) => (
-            <NewsList key={idx} {...item} list_id={idx + 10} />
+            <RankingNewsList key={idx} {...item} list_id={idx + 10} />
           ))}
         </div>
       </div>

--- a/src/pages/components/RankingSection/index.tsx
+++ b/src/pages/components/RankingSection/index.tsx
@@ -4,7 +4,7 @@ const RankingSection = () => {
   return (
     <div className="md:w-[53%] w-full flex flex-col gap-5">
       <h4 className="font-SAM3 md:text-[28px] text-[23px] md:mb-3 mb-1">Ranking</h4>
-      <div className="flex flex-col gap-5 pl-2">
+      <div className="flex flex-col gap-5 md:pl-2 pl-[8%]">
         <div className="w-full flex md:gap-5 gap-3">
           <PressBadge name="SBS" />
           <PressBadge name="KBS" />

--- a/src/pages/components/WeatherSection/index.tsx
+++ b/src/pages/components/WeatherSection/index.tsx
@@ -49,13 +49,13 @@ const WeatherSection = () => {
 
   return (
     <div className="md:w-[47%] w-full h-full flex flex-col gap-5 p-5 bg-CARD_BG_DARK rounded-md font-SAM3">
-      <div className="w-full h-[50%] flex justify-between gap-5 text-lg">
+      <div className="w-full h-[55%] flex justify-between gap-5 text-lg">
         <div className="flex flex-col">
           <p className="text-[25px]">
             {month}/{date}
           </p>
           <p>{weatherData?.name}</p>
-          <div className="w-full flex gap-3 items-center mt-3 -md-1">
+          <div className="w-full flex gap-3 items-center pt-1.5 -md-1">
             <span
               className={`w-[18px] h-[18px] rounded-full flex items-center justify-center bg-${weatherData?.main.humidity >= 40 && weatherData?.main.humidity <= 55 ? "blue" : weatherData?.main.humidity > 55 && weatherData?.main.humidity <= 65 ? "green" : weatherData?.main.humidity > 65 && weatherData?.main.humidity <= 70 ? "yellow" : weatherData?.main.humidity > 70 && weatherData?.main.humidity <= 75 ? "orange" : "red"}-500`}
             >
@@ -63,7 +63,7 @@ const WeatherSection = () => {
             </span>
             <span>{weatherData?.main.humidity}%</span>
           </div>
-          <div className="w-full flex gap-3 items-center">
+          <div className="w-full flex gap-3 items-center -mt-0.5">
             <span
               className={`w-[18px] h-[18px] rounded-full flex items-center justify-center bg-${airQuality?.list[0].main.aqi === 1 ? "blue" : airQuality?.list[0].main.aqi === 2 ? "green" : airQuality?.list[0].main.aqi === 3 ? "yellow" : airQuality?.list[0].main.aqi === 4 ? "orange" : "red"}-500`}
             >
@@ -83,13 +83,14 @@ const WeatherSection = () => {
           </div>
         </div>
         <div className="flex flex-col items-end">
-          <div className="w-[70px] h-[70px]">
+          <div className="w-[75px] h-[75px]">
             {weatherData?.weather[0].icon && (
               <Image
                 src={`https://openweathermap.org/img/wn/${weatherData?.weather[0].icon}@2x.png`}
                 alt="weather icon"
                 width={100}
                 height={100}
+                priority
               />
             )}
           </div>

--- a/src/pages/components/mainHome/index.tsx
+++ b/src/pages/components/mainHome/index.tsx
@@ -9,15 +9,16 @@ import it from "../../../../public/images/it.png";
 const MainHome = () => {
   return (
     <div className="w-[100vw] h-[100%] p-0">
-      <div className="w-[100vw] h-80 mt-[20px] bg-MAIN_BG_LIGHT dark:bg-MAIN_BG_DARK p-8 flex flex-col justify-center items-center gap-2">
+      <div className="w-[100vw] h-80 mt-[20px] bg-MAIN_BG_LIGHT dark:bg-MAIN_BG_DARK md:p-8 p-10 flex flex-col md:items-center justify-center items-start gap-2">
         <p className="md:text-xl text-lg">Nhips = 📰 + 🍪 !</p>
         <p className="md:text-lg text-sm">
-          뉴스를 가볍게 간식처럼 즐길 순 없을까? 하는 생각으로 만들었어요.
+          뉴스를 가볍게 간식처럼 즐길 순 없을까? <br className="md:hidden" />
+          하는 생각으로 만들었어요.
         </p>
         <p className="md:text-lg text-sm">
-          아래 아이콘을 클릭하면 각 Topic 뉴스 페이지로 이동해요!
+          아래 아이콘을 클릭하면 <br className="md:hidden" />각 Topic 뉴스 페이지로 이동해요!
         </p>
-        <p className="md:text-sm text-[11px] md:mt-5 mt-3 md:text-GRAY text-GRAY_DARK">
+        <p className="md:text-xs text-[10px] md:mt-5 mt-3 md:text-GRAY text-GRAY_DARK">
           ** 아래 아이콘은 각 Topic 영문 첫글자를 따서 만들어졌어요 !
         </p>
       </div>

--- a/src/pages/ranking/[pressname]/index.tsx
+++ b/src/pages/ranking/[pressname]/index.tsx
@@ -1,33 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import axios from "axios";
-import { RankingType } from "@/types/DataType";
 import Layout from "@/components/Layout";
-import RankingRack from "./RankingRack";
+import RankingNewsRack from "../../components/NewsItems/RankingNewsRack";
+import { useRankingDatas } from "src/hooks/useRankingDatas";
 
-const PressRankingPage = () => {
+const PressRankingNewsPage = () => {
   const router = useRouter();
-  const { pressname } = router.query;
+  const { pressname }: any = router.query;
 
-  const [data, setData] = useState<RankingType>({
-    pressName: "",
-    pressImgSrc: "",
-    pressContent: [],
-  });
+  const { data, isLoading } = useRankingDatas(pressname);
 
-  useEffect(() => {
-    axios.get(`/api/ranking/${pressname}`).then((res) => {
-      // console.log(res);
-      setData(res.data);
-    });
-  }, []);
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
 
   return (
     <>
       <Layout>
-        <RankingRack key="mainhome" {...data} />
+        <>{data && <RankingNewsRack {...data} />}</>
       </Layout>
     </>
   );
@@ -37,4 +28,4 @@ export async function getServerSideProps(context: any) {
   return { props: { pressname: context.params.pressname } };
 }
 
-export default PressRankingPage;
+export default PressRankingNewsPage;

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,52 @@
+import { GetServerSideProps } from "next";
+import { format } from "date-fns";
+
+const Sitemap = () => {
+  return null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://doyeonlee.vercel.app/";
+
+  // 정적 페이지 URL 목록
+  const staticPages = [
+    `${baseUrl}/`,
+    `${baseUrl}/social`,
+    `${baseUrl}/world`,
+    `${baseUrl}/economy`,
+    `${baseUrl}/politics`,
+    `${baseUrl}/it-science`,
+  ];
+
+  // 동적 라우트의 pressname 값을 설정
+  const pressnames = ["YH", "MBC", "SBS", "MBN", "KBS", "YTN", "CA", "HAN"];
+  const dynamicPages = pressnames.map((pressname) => `${baseUrl}/ranking/${pressname}`);
+
+  // 모든 페이지 URL 통합
+  const allPages = [...staticPages, ...dynamicPages];
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ${allPages
+      .map((url) => {
+        return `
+          <url>
+            <loc>${url}</loc>
+            <lastmod>${format(new Date(), "yyyy-MM-dd")}</lastmod>
+            <changefreq>daily</changefreq>
+            <priority>0.7</priority>
+          </url>
+        `;
+      })
+      .join("")}
+  </urlset>`;
+
+  res.setHeader("Content-Type", "text/xml");
+  res.write(sitemap);
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default Sitemap;

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#18

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### Ranking 데이터 최적화
> cache를 사용한 Ranking 데이터 최적화 및 preload를 사용하기 위해 설정
- [x] ranking 페이지에 react-query 적용
- [x] 데이터를 preload 해올 수 있도록 설정
- [x] api에 ETag 관련 설정을 부여
  - 암호화된 기존 데이터와 새로운 데이터가 같을 경우 = 304 Not Modified -> cache 사용
  - 기존 데이터와 새로운 데이터가 다를 경우 = 200 Success  -> 새로운 데이터로 업데이트
  - 기대 효과: 불필요한 요청을 줄일 수 있다.

---
### SEO 최적화
> 검색 엔진에 잘 뜨게 하기 위해 SEO 관련 설정을 해줌.
- [x] sitemap.xml.ts 설정
- [x] robot.txt 설정
- [x] date-fns 패키지 추가
- [x] 기존 DEFAULT_SEO 설정 title 영어 + 한글로 수정
- [x] .env.local 설정에 따른 gitignore 업데이트
